### PR TITLE
Update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",
-    "strict": true
+    "strict": true,
+    "rootDir": "./src"
   },
-  "include": ["src", "test"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
The package can't be used appropriately with the current package.json paths to the lib directory and current tsconfig.json file setup. 

The solution would be the changes in tsconfig.json:
1. remove tests from the `lib` output; we don't need them, do we?
2. This will flatten the lib directory to match paths defined in the package.json

As additional improvements (not added here):
1. there is an npm audit error that can be fixed by running `npm audit fix`. The package-lock.json will need to be pushed then. I wanted to avoid touching the package-lock here.

I saw that it is used like: `@multiversx/sdk-transaction-decoder/lib/src/transaction.decoder`, so it will probably be a breaking change (sort of, breaking by fixing ;)), but I think it would be worth fixing that