### PR TITLE
Do not remove functionName & functionArgs if no args but receiver is smart contract 

### DIFF
--- a/test/decoder.test.ts
+++ b/test/decoder.test.ts
@@ -17,6 +17,24 @@ test('Simple wallet to wallet transfer with dummy data text', () => {
   });
 });
 
+test('Smart contract call without arguments', () => {
+  const decoder = new TransactionDecoder();
+  const metadata = decoder.getTransactionMetadata({
+    sender: 'erd18w6yj09l9jwlpj5cjqq9eccfgulkympv7d4rj6vq4u49j8fpwzwsvx7e85',
+    receiver: 'erd1qqqqqqqqqqqqqpgqmua7hcd05yxypyj7sv7pffrquy9gf86s535qxct34s',
+    data: 'bXlFbmRwb2ludA==',
+    value: '0',
+  });
+
+  expect(metadata).toEqual<TransactionMetadata>({
+    sender: 'erd18w6yj09l9jwlpj5cjqq9eccfgulkympv7d4rj6vq4u49j8fpwzwsvx7e85',
+    receiver: 'erd1qqqqqqqqqqqqqpgqmua7hcd05yxypyj7sv7pffrquy9gf86s535qxct34s',
+    value: BigInt('0'),
+    functionName: 'myEndpoint',
+    functionArgs: [],
+  });
+});
+
 test('NFT Smart contract call', () => {
   const decoder = new TransactionDecoder();
   const metadata = decoder.getTransactionMetadata({

--- a/test/decoder.test.ts
+++ b/test/decoder.test.ts
@@ -13,7 +13,7 @@ test('Simple wallet to wallet transfer with dummy data text', () => {
     sender: 'erd18w6yj09l9jwlpj5cjqq9eccfgulkympv7d4rj6vq4u49j8fpwzwsvx7e85',
     receiver: 'erd1lkrrrn3ws9sp854kdpzer9f77eglqpeet3e3k3uxvqxw9p3eq6xqxj43r9',
     value: BigInt('10000000000000000'),
-    functionName: 'transfer'
+    functionName: 'transfer',
   });
 });
 


### PR DESCRIPTION
We are getting `functionName = "transfer"` and `functionArgs = undefined` when a transaction is a smart contract call without any argument.

This PR adds a check that verify if the receiver is not a smart contract before making `functionName` to "transfer" and `functionArgs` to `undefined`